### PR TITLE
pts/schbench: Make the workload instance number scaling with the onli…

### DIFF
--- a/pts/schbench-1.0.1/downloads.xml
+++ b/pts/schbench-1.0.1/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.8.0m3-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://phoronix-test-suite.com/benchmark-files/schbench-20180206.zip</URL>
+      <MD5>36bfb992f7288dc60cbfb65f879879ab</MD5>
+      <SHA256>626d29648b270895711c2a458fffa841b2c6a19f9115f8080dcd98a1aef3f4bb</SHA256>
+      <FileSize>39570</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/schbench-1.0.1/install.sh
+++ b/pts/schbench-1.0.1/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+unzip -o schbench-20180206.zip
+cd schbench/
+make
+echo $? > ~/install-exit-status
+cd ~
+
+echo "#!/bin/sh
+cd schbench/
+
+NR_WORKER=\$((NUM_CPU_CORES/4))
+if [ \$NR_WORKER -eq 0 ]
+then
+	\$NR_WORKER=1
+fi
+
+./schbench \$@ -t \$NR_WORKER > \$LOG_FILE 2>&1
+
+echo \$? > ~/test-exit-status" > schbench-run
+chmod +x schbench-run

--- a/pts/schbench-1.0.1/results-definition.xml
+++ b/pts/schbench-1.0.1/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.8.0m3-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>	99.9000th: #_RESULT_#</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/schbench-1.0.1/test-definition.xml
+++ b/pts/schbench-1.0.1/test-definition.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.8.0m3-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Schbench</Title>
+    <Description>This is a benchmark of Schbench, a Linux kernel scheduler benchmark developed by Facebook.</Description>
+    <ResultScale>usec, 99.9th Latency Percentile</ResultScale>
+    <Proportion>LIB</Proportion>
+    <Executable>schbench-run</Executable>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.1</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git/</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>-r 30 </Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Message Threads</DisplayName>
+      <Identifier>msg-threads</Identifier>
+      <ArgumentPrefix>-m </ArgumentPrefix>
+      <ArgumentPostfix></ArgumentPostfix>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>2</Name>
+          <Value>2</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>4</Name>
+          <Value>4</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>8</Name>
+          <Value>8</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>16</Name>
+          <Value>16</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
…ne core number

There is requirement to launch the schbench according to the online CPU number. After adjustment, the schbench will launch specified number of message threads, and each of the message thread has 1/4 online CPUs number of worker threads.

Signed-off-by: Chen Yu <yu.c.chen@intel.com>