### PR TITLE
pts/sqlite-2.1.1: Add scalability test support

### DIFF
--- a/pts/sqlite-2.1.1/downloads.xml
+++ b/pts/sqlite-2.1.1/downloads.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://sqlite.org/2019/sqlite-autoconf-3300100.tar.gz</URL>
+      <MD5>51252dc6bc9094ba11ab151ba650ff3c</MD5>
+      <SHA256>8c5a50db089bd2a1b08dbc5b00d2027602ca7ff238ba7658fabca454d4298e60</SHA256>
+      <FileName>sqlite-autoconf-3300100.tar.gz</FileName>
+      <FileSize>2848951</FileSize>
+    </Package>
+    <Package>
+      <URL>http://sqlite.org/2019/sqlite-tools-win32-x86-3300100.zip</URL>
+      <MD5>6211b900660fa63f4dbaa6ab0734a9d0</MD5>
+      <SHA256>64027558a7928fe7e6e5cbed0471a0b709591276ce132a457ec09bddca887258</SHA256>
+      <FileName>sqlite-tools-win32-x86-3300100.zip</FileName>
+      <FileSize>1806671</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/pts-sqlite-tests-1.tar.gz, http://www.phoronix.net/downloads/phoronix-test-suite/benchmark-files/pts-sqlite-tests-1.tar.gz</URL>
+      <MD5>153e725642619e38766ddf8359f65cfe</MD5>
+      <SHA256>1067f047461e21fd56e2a6ae03043c687047d00192ffdbe5b52271cd39de442f</SHA256>
+      <FileName>pts-sqlite-tests-1.tar.gz</FileName>
+      <FileSize>42835</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/sqlite-2.1.1/install.sh
+++ b/pts/sqlite-2.1.1/install.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+tar -zxvf pts-sqlite-tests-1.tar.gz
+tar -zxvf sqlite-autoconf-3300100.tar.gz
+mkdir sqlite_/
+
+cd sqlite-autoconf-3300100/
+./configure --prefix=$HOME/sqlite_/
+make
+echo $? > ~/install-exit-status
+make install
+cd ..
+rm -rf sqlite-autoconf-3300100/
+
+echo "#!/bin/bash
+
+cat sqlite-2500-insertions.txt > sqlite-insertions.txt
+do_test() {
+    DB=benchmark-\$1.db
+    ./sqlite_/bin/sqlite3 \$DB  \"CREATE TABLE pts1 ('I' SMALLINT NOT NULL, 'DT' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 'F1' VARCHAR(4) NOT NULL, 'F2' VARCHAR(16) NOT NULL);\"
+    cat sqlite-insertions.txt | ./sqlite_/bin/sqlite3 \$DB
+    cat sqlite-insertions.txt | ./sqlite_/bin/sqlite3 \$DB
+    cat sqlite-insertions.txt | ./sqlite_/bin/sqlite3 \$DB
+}
+pids=\"\"
+for i in \$(seq 1 \$NUM_CPU_CORES)
+do
+    do_test \$i &
+    pids=\"\$pids \$!\"
+done
+wait \$pids" > sqlite-benchmark
+chmod +x sqlite-benchmark

--- a/pts/sqlite-2.1.1/install_windows.sh
+++ b/pts/sqlite-2.1.1/install_windows.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+tar -zxvf pts-sqlite-tests-1.tar.gz
+unzip -o sqlite-tools-win32-x86-3300100.zip
+
+echo "#!/bin/bash
+
+cat sqlite-2500-insertions.txt > sqlite-insertions.txt
+do_test() {
+    DB=benchmark-\$1.db
+    ./sqlite-tools-win32-x86-3300100/sqlite3.exe \$DB  \"CREATE TABLE pts1 ('I' SMALLINT NOT NULL, 'DT' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 'F1' VARCHAR(4) NOT NULL, 'F2' VARCHAR(16) NOT NULL);\"
+    cat sqlite-insertions.txt | ./sqlite-tools-win32-x86-3300100/sqlite3.exe \$DB
+    cat sqlite-insertions.txt | ./sqlite-tools-win32-x86-3300100/sqlite3.exe \$DB
+    cat sqlite-insertions.txt | ./sqlite-tools-win32-x86-3300100/sqlite3.exe \$DB
+}
+pids=\"\"
+for i in \$(seq 1 \$NUM_CPU_CORES)
+do
+    do_test \$i &
+    pids=\"\$pids \$!\"
+done
+wait \$pids" > sqlite-benchmark
+chmod +x sqlite-benchmark

--- a/pts/sqlite-2.1.1/interim.sh
+++ b/pts/sqlite-2.1.1/interim.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f benchmark*.db

--- a/pts/sqlite-2.1.1/post.sh
+++ b/pts/sqlite-2.1.1/post.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f benchmark*.db

--- a/pts/sqlite-2.1.1/pre.sh
+++ b/pts/sqlite-2.1.1/pre.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f benchmark*.db

--- a/pts/sqlite-2.1.1/results-definition.xml
+++ b/pts/sqlite-2.1.1/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/sqlite-2.1.1/test-definition.xml
+++ b/pts/sqlite-2.1.1/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>SQLite</Title>
+    <AppVersion>3.30.1</AppVersion>
+    <Description>This is a simple benchmark of SQLite. At present this test profile just measures the time to perform a pre-defined number of insertions on an indexed database.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Timed SQLite Insertions</SubTitle>
+    <Executable>sqlite-benchmark</Executable>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.1.1</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX, Solaris, Windows</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Disk</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>22</EnvironmentSize>
+    <ProjectURL>http://www.sqlite.org/</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
This test config launches the number of instances based on the online CPUs.